### PR TITLE
Add scout page with match fetch

### DIFF
--- a/src/components/BuscaScout.jsx
+++ b/src/components/BuscaScout.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+const BuscaScout = () => {
+  const [matches, setMatches] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const loadMatches = async () => {
+      try {
+        const response = await fetch('/api/matches');
+        if (!response.ok) throw new Error('Erro ao buscar dados');
+        const data = await response.json();
+        setMatches(data.matches || []);
+      } catch (err) {
+        setError('Falha ao carregar partidas');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadMatches();
+  }, []);
+
+  if (loading) return <p className="text-center">Carregando...</p>;
+  if (error) return <p className="text-center text-red-600">{error}</p>;
+
+  return (
+    <div className="space-y-2">
+      {matches.map((match, idx) => (
+        <div key={idx} className="p-4 bg-gray-100 rounded">
+          <p className="font-semibold">
+            {match.teams?.home?.name} x {match.teams?.away?.name}
+          </p>
+          <p className="text-sm text-gray-500">{match.fixture?.date || ''}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BuscaScout;

--- a/src/pages/PaginaScout.jsx
+++ b/src/pages/PaginaScout.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const PaginaScout = () => (
-  <div className="p-4 text-center">Scout Page</div>
-);
-
-export default PaginaScout;

--- a/src/pages/ScoutPage.jsx
+++ b/src/pages/ScoutPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import BuscaScout from '@/components/BuscaScout';
+
+export default function ScoutPage() {
+  return (
+    <main className="min-h-screen bg-white p-6">
+      <h1 className="text-2xl font-bold text-center mb-4">Painel do Scout</h1>
+      <BuscaScout />
+    </main>
+  );
+}

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -7,7 +7,7 @@ import DashboardEmpresario from '../pages/DashboardEmpresario.jsx';
 import PainelAdmin from '../pages/PainelAdmin.jsx';
 import PaginaCadastro from '../pages/PaginaCadastro.jsx';
 import PaginaCadastroAvancado from '../pages/PaginaCadastroAvancado.jsx';
-import PaginaScout from '../pages/PaginaScout.jsx';
+import ScoutPage from '../pages/ScoutPage.jsx';
 
 const AppRoutes = () => (
   <Routes>
@@ -18,7 +18,7 @@ const AppRoutes = () => (
     <Route path="/admin" element={<PainelAdmin />} />
     <Route path="/cadastro" element={<PaginaCadastro />} />
     <Route path="/cadastroavancado" element={<PaginaCadastroAvancado />} />
-    <Route path="/scout" element={<PaginaScout />} />
+    <Route path="/scout" element={<ScoutPage />} />
   </Routes>
 );
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## Summary
- create `BuscaScout` component that fetches `/api/matches`
- add `ScoutPage` page that uses the component
- update routes to use `ScoutPage`
- add alias config to Vite for `@` path
- remove old `PaginaScout` page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68559233b668832cb000a316d290d186