### PR TITLE
Add Player Statistics page

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -8,6 +8,7 @@ const HomePage = () => (
       <Link to="/dashboard-jogador" className="block w-full py-3 rounded-2xl shadow bg-gray-800 hover:bg-gray-700 text-center">Enter as Player</Link>
       <Link to="/dashboard-clube" className="block w-full py-3 rounded-2xl shadow bg-gray-800 hover:bg-gray-700 text-center">Enter as Club</Link>
       <Link to="/dashboard-empresario" className="block w-full py-3 rounded-2xl shadow bg-gray-800 hover:bg-gray-700 text-center">Enter as Agent</Link>
+      <Link to="/player-stats" className="block w-full py-3 rounded-2xl shadow bg-gray-800 hover:bg-gray-700 text-center">Player Statistics</Link>
     </div>
   </div>
 );

--- a/src/pages/PlayerStatistics.jsx
+++ b/src/pages/PlayerStatistics.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const PlayerStatistics = () => (
+  <div className="p-4 text-center">
+    <h1 className="text-2xl font-bold mb-4">Player Statistics</h1>
+    <p className="text-gray-700">Coming soon: detailed player statistics.</p>
+  </div>
+);
+
+export default PlayerStatistics;

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -9,6 +9,7 @@ import PaginaCadastro from '../pages/PaginaCadastro.jsx';
 import PaginaCadastroAvancado from '../pages/PaginaCadastroAvancado.jsx';
 import ScoutPage from '../pages/ScoutPage.jsx';
 import TransferLab from '../components/TransferLab.jsx';
+import PlayerStatistics from '../pages/PlayerStatistics.jsx';
 
 const AppRoutes = () => (
   <Routes>
@@ -20,6 +21,7 @@ const AppRoutes = () => (
     <Route path="/cadastro" element={<PaginaCadastro />} />
     <Route path="/cadastroavancado" element={<PaginaCadastroAvancado />} />
     <Route path="/scout" element={<ScoutPage />} />
+    <Route path="/player-stats" element={<PlayerStatistics />} />
     <Route path="/transferlab" element={<TransferLab />} />
   </Routes>
 );


### PR DESCRIPTION
## Summary
- create `PlayerStatistics` page
- register `/player-stats` route
- link to the new stats page from `HomePage`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856c4f19354832c8c7b1da061a799d9